### PR TITLE
Change API key to a publicly open one

### DIFF
--- a/templates/map.twig
+++ b/templates/map.twig
@@ -29,7 +29,7 @@
 	<div id="found-yours-box" class="content-box hidden"></div>
 </div>
 
-<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?sensor=false&key=AIzaSyBstJfoA83_8cLCKgtgtAqSda1YoRudtB4 "></script>
+<script type="text/javascript" src="//maps.googleapis.com/maps/api/js?sensor=false&key=AIzaSyD1ciSCuzPCq-5sHGG86numr0Oc6OJoZ5o"></script>
 <script type="text/javascript" src="{{site.theme.link}}/static/js/geolib.js"></script>
 <script type="text/javascript" src="{{site.theme.link}}/static/js/markercluster.js"></script>
 <script type="text/javascript">


### PR DESCRIPTION
This way members of the community won't have to require a change in our key (domain restriction) nor have to generate one (why doesn't the map work?)